### PR TITLE
cURLHandle manages initializing libcURL for all curl handle subclasses

### DIFF
--- a/cURL.rbvcp
+++ b/cURL.rbvcp
@@ -5,6 +5,7 @@ Window=Window1;Window1.rbfrm;&h78794FFF;&h0;false
 Window=FormGenerator;FormGenerator.rbfrm;&h4CBCE7FF;&h0;false
 BuildSteps=Build Automation;Build Automation.rbbas;&h4A2D3FFF;&h0;false
 Module=libcURL;libcURL/libcURL.rbbas;&h1B9FF7FF;&h0;false
+Class=cURLHandle;libcURL/cURLHandle.rbbas;&h40F2C7FF;&h1B9FF7FF;false
 Class=cURLShare;libcURL/cURLShare.rbbas;&h539AFFF;&h1B9FF7FF;false
 Interface=ErrorHandler;libcURL/ErrorHandler.rbbas;&h4E0DAFFF;&h1B9FF7FF;false
 Module=SynchronousHelpers;libcURL/SynchronousHelpers.rbbas;&h5C3117FF;&h1B9FF7FF;false

--- a/libcURL/Form.rbbas
+++ b/libcURL/Form.rbbas
@@ -1,5 +1,6 @@
 #tag Class
 Protected Class Form
+Inherits libcURL.cURLHandle
 Implements ErrorHandler
 	#tag Method, Flags = &h0
 		Function AddElement(Name As String, Value As Variant) As Boolean
@@ -40,17 +41,10 @@ Implements ErrorHandler
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor()
-		  ' initialize libcURL just enough to handle form building
-		  
-		  If Not libcURL.IsAvailable Then
-		    Dim err As New PlatformNotSupportedException
-		    err.Message = "libcURL is not available or is an unsupported version."
-		    Raise err
-		  End If
-		  
-		  If curl_global_init(CURL_GLOBAL_DEFAULT) <> 0 Then 
-		    mLastError = libcURL.Errors.INIT_FAILED
+		Sub Constructor(GlobalInitFlags As Integer = libcURL.CURL_GLOBAL_NOTHING)
+		  ' initialize libcURL
+		  Super.Constructor(GlobalInitFlags)
+		  If mLastError <> 0 Then
 		    Raise New cURLException(Me)
 		  End If
 		End Sub
@@ -58,10 +52,9 @@ Implements ErrorHandler
 
 	#tag Method, Flags = &h21
 		Private Sub Destructor()
-		  If libcURL.IsAvailable Then
-		    If FirstItem <> Nil Then libcURL.curl_formfree(FirstItem)
-		    libcURL.curl_global_cleanup()
-		  End If
+		  If libcURL.IsAvailable And FirstItem <> Nil Then libcURL.curl_formfree(FirstItem)
+		  FirstItem = Nil
+		  LastItem = Nil
 		End Sub
 	#tag EndMethod
 
@@ -70,20 +63,6 @@ Implements ErrorHandler
 		  ' This method returns a Ptr to the form structure which can be passed back to libcURL
 		  Return FirstItem
 		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		Function LastError() As Integer
-		  // Part of the libcURL.ErrorHandler interface.
-		  Return mLastError
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h21
-		Private Sub LastError(Assigns NewError As Integer)
-		  // Part of the libcURL.ErrorHandler interface.
-		  mLastError = NewError
-		End Sub
 	#tag EndMethod
 
 
@@ -114,10 +93,6 @@ Implements ErrorHandler
 
 	#tag Property, Flags = &h1
 		Protected LastItem As Ptr
-	#tag EndProperty
-
-	#tag Property, Flags = &h1
-		Protected mLastError As Integer
 	#tag EndProperty
 
 

--- a/libcURL/cURLHandle.rbbas
+++ b/libcURL/cURLHandle.rbbas
@@ -1,0 +1,148 @@
+#tag Class
+Protected Class cURLHandle
+	#tag Method, Flags = &h1
+		Protected Sub Constructor(Flags As Integer)
+		  If Not libcURL.IsAvailable Then
+		    Dim err As New PlatformNotSupportedException
+		    err.Message = "libcURL is not available or is an unsupported version."
+		    Raise err
+		  End If
+		  
+		  Select Case Flags
+		  Case CURL_GLOBAL_ALL
+		    If Not Win32Init Or Not SSLInit Then
+		      mLastError = curl_global_init(Flags)
+		      If mLastError <> 0 Then Return
+		      Win32Init = True
+		      SSLInit = True
+		      mInitCount = mInitCount + 1
+		    End If
+		     
+		  Case CURL_GLOBAL_WIN32
+		    If Not Win32Init Then
+		      mLastError = curl_global_init(Flags)
+		      If mLastError <> 0 Then Return
+		      Win32Init = True
+		      mInitCount = mInitCount + 1
+		    End If
+		    
+		  Case CURL_GLOBAL_SSL
+		    If Not SSLInit Then
+		      mLastError = curl_global_init(Flags)
+		      If mLastError <> 0 Then Return
+		      SSLInit = True
+		      mInitCount = mInitCount + 1
+		    End If
+		    
+		  Case CURL_GLOBAL_NOTHING
+		    If mInitCount = 0 Then
+		      mLastError = curl_global_init(Flags)
+		      If mLastError <> 0 Then Return
+		      mInitCount = mInitCount + 1
+		    End If
+		    
+		  End Select
+		  
+		  If mLastError = 0 Then mRefCount = mRefCount + 1
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h21
+		Private Sub Destructor()
+		  If mInitCount > 0 Then mRefCount = mRefCount - 1
+		  If mRefCount <= 0 Then 
+		    For i As Integer = 0 To mInitCount
+		      If libcURL.IsAvailable Then curl_global_cleanup()
+		      'mInitCount = Max(mInitCount - 1, 0)
+		    Next
+		    Win32Init = False
+		    SSLInit = False
+		    NothingInit = False
+		    mInitCount = 0
+		    mRefCount = 0
+		  End If
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function LastError() As Integer
+		  // Part of the libcURL.ErrorHandler interface.
+		  ' All calls into libcURL that return an error code will update LastError
+		  ' See:
+		  ' https://github.com/charonn0/RB-libcURL/wiki/libcURL.Errors
+		  ' https://github.com/charonn0/RB-libcURL/wiki/libcURL.FormatError
+		  
+		  Return mLastError
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub LastError(Assigns NewError As Integer)
+		  // Part of the libcURL.ErrorHandler interface.
+		  mLastError = NewError
+		End Sub
+	#tag EndMethod
+
+
+	#tag Property, Flags = &h21
+		Private Shared mInitCount As Integer
+	#tag EndProperty
+
+	#tag Property, Flags = &h1
+		Protected mLastError As Integer
+	#tag EndProperty
+
+	#tag Property, Flags = &h21
+		Private Shared mRefCount As Integer
+	#tag EndProperty
+
+	#tag Property, Flags = &h21
+		Private Shared NothingInit As Boolean
+	#tag EndProperty
+
+	#tag Property, Flags = &h21
+		Private Shared SSLInit As Boolean
+	#tag EndProperty
+
+	#tag Property, Flags = &h21
+		Private Shared Win32Init As Boolean
+	#tag EndProperty
+
+
+	#tag ViewBehavior
+		#tag ViewProperty
+			Name="Index"
+			Visible=true
+			Group="ID"
+			InitialValue="-2147483648"
+			InheritedFrom="Object"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Left"
+			Visible=true
+			Group="Position"
+			InitialValue="0"
+			InheritedFrom="Object"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Name"
+			Visible=true
+			Group="ID"
+			InheritedFrom="Object"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Super"
+			Visible=true
+			Group="ID"
+			InheritedFrom="Object"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Top"
+			Visible=true
+			Group="Position"
+			InitialValue="0"
+			InheritedFrom="Object"
+		#tag EndViewProperty
+	#tag EndViewBehavior
+End Class
+#tag EndClass

--- a/libcURL/cURLItem.rbbas
+++ b/libcURL/cURLItem.rbbas
@@ -245,10 +245,7 @@ Implements ErrorHandler
 		  ' https://github.com/charonn0/RB-libcURL/wiki/cURLItem.Destructor
 		  
 		  Me.Close()
-		  If Instances = Nil Or Instances.Count = 0 Then
-		    If libcURL.IsAvailable Then curl_global_cleanup()
-		    Instances = Nil
-		  End If
+		  If Instances <> Nil And Instances.Count = 0 Then Instances = Nil
 		End Sub
 	#tag EndMethod
 

--- a/libcURL/cURLItem.rbbas
+++ b/libcURL/cURLItem.rbbas
@@ -36,27 +36,16 @@ Implements ErrorHandler
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor()
+		Sub Constructor(GlobalInitFlags As Integer = libcURL.CURL_GLOBAL_DEFAULT)
 		  ' Initializes libcURL if necessary and creates a new curl_easy handle
 		  ' See:
 		  ' http://curl.haxx.se/libcurl/c/curl_global_init.html
 		  ' http://curl.haxx.se/libcurl/c/curl_easy_init.html
 		  ' https://github.com/charonn0/RB-libcURL/wiki/cURLItem.Constructor
 		  
-		  If Not libcURL.IsAvailable Then
-		    Dim err As New PlatformNotSupportedException
-		    err.Message = "libcURL is not available or is an unsupported version."
-		    Raise err
-		  End If
-		  
-		  If Instances = Nil Then
-		    mLastError = curl_global_init(CURL_GLOBAL_DEFAULT)
-		    If mLastError = 0 Then
-		      Instances = New Dictionary
-		    Else
-		      Raise New cURLException(Me)
-		    End If
-		  End If
+		  Super.Constructor(GlobalInitFlags)
+		  If mLastError <> 0 Then Raise New cURLException(Me)
+		  If Instances = Nil Then Instances = New Dictionary
 		  
 		  mHandle = curl_easy_init()
 		  If mHandle > 0 Then

--- a/libcURL/cURLItem.rbbas
+++ b/libcURL/cURLItem.rbbas
@@ -1,5 +1,6 @@
 #tag Class
 Protected Class cURLItem
+Inherits libcURL.cURLHandle
 Implements ErrorHandler
 	#tag Method, Flags = &h0
 		Sub Close()
@@ -372,25 +373,6 @@ Implements ErrorHandler
 		  
 		  If Not Sender.SetOption(libcURL.Opts.DEBUGDATA, Sender.Handle) Then Raise New cURLException(Sender)
 		  If Not Sender.SetOption(libcURL.Opts.DEBUGFUNCTION, AddressOf DebugCallback) Then Raise New cURLException(Sender)
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		Function LastError() As Integer
-		  // Part of the libcURL.ErrorHandler interface.
-		  ' All calls into libcURL that return an error code will update LastError
-		  ' See:
-		  ' https://github.com/charonn0/RB-libcURL/wiki/libcURL.Errors
-		  ' https://github.com/charonn0/RB-libcURL/wiki/libcURL.FormatError
-		  
-		  Return mLastError
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h21
-		Private Sub LastError(Assigns NewError As Integer)
-		  // Part of the libcURL.ErrorHandler interface.
-		  mLastError = NewError
 		End Sub
 	#tag EndMethod
 
@@ -827,10 +809,6 @@ Implements ErrorHandler
 
 	#tag Property, Flags = &h1
 		Protected mHandle As Integer
-	#tag EndProperty
-
-	#tag Property, Flags = &h1
-		Protected mLastError As Integer
 	#tag EndProperty
 
 	#tag Property, Flags = &h21

--- a/libcURL/cURLItem.rbbas
+++ b/libcURL/cURLItem.rbbas
@@ -37,7 +37,7 @@ Implements ErrorHandler
 
 	#tag Method, Flags = &h0
 		Sub Constructor(GlobalInitFlags As Integer = libcURL.CURL_GLOBAL_DEFAULT)
-		  ' Initializes libcURL if necessary and creates a new curl_easy handle
+		  ' Creates a new curl_easy handle
 		  ' See:
 		  ' http://curl.haxx.se/libcurl/c/curl_global_init.html
 		  ' http://curl.haxx.se/libcurl/c/curl_easy_init.html

--- a/libcURL/cURLShare.rbbas
+++ b/libcURL/cURLShare.rbbas
@@ -27,10 +27,10 @@ Inherits libcURL.cURLMulti
 	#tag EndMethod
 
 	#tag Method, Flags = &h1000
-		Sub Constructor()
+		Sub Constructor(GlobalInitFlags As Integer = libcURL.CURL_GLOBAL_DEFAULT)
 		  // Calling the overridden superclass constructor.
 		  // Constructor() -- From cURLMulti
-		  Super.Constructor()
+		  Super.Constructor(GlobalInitFlags)
 		  mShareHandle = curl_share_init()
 		  If mShareHandle = 0 Then
 		    mLastError = libcURL.Errors.INIT_FAILED

--- a/libcURL/curl_slist.rbbas
+++ b/libcURL/curl_slist.rbbas
@@ -1,5 +1,6 @@
 #tag Class
 Protected Class curl_slist
+Inherits libcURL.cURLHandle
 Implements ErrorHandler
 	#tag Method, Flags = &h0
 		Function Append(s As String) As Boolean
@@ -16,29 +17,18 @@ Implements ErrorHandler
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(ListPtr As Ptr = Nil)
-		  ' initialize libcURL just enough to handle list building
-		  
-		  If Not libcURL.IsAvailable Then
-		    Dim err As New PlatformNotSupportedException
-		    err.Message = "libcURL is not available or is an unsupported version."
-		    Raise err
-		  End If
-		  
-		  If curl_global_init(CURL_GLOBAL_DEFAULT) <> 0 Then 
-		    mLastError = libcURL.Errors.INIT_FAILED
-		    Raise New cURLException(Me)
-		  End If
+		Sub Constructor(ListPtr As Ptr = Nil, GlobalInitFlags As Integer = libcURL.CURL_GLOBAL_NOTHING)
+		  ' initialize libcURL
+		  Super.Constructor(GlobalInitFlags)
+		  If mLastError <> 0 Then Raise New cURLException(Me)
 		  List = ListPtr
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h21
 		Private Sub Destructor()
-		  If libcURL.IsAvailable Then
-		    If List <> Nil Then libcURL.curl_slist_free_all(List)
-		    libcURL.curl_global_cleanup()
-		  End If
+		  If libcURL.IsAvailable And List <> Nil Then libcURL.curl_slist_free_all(List)
+		  List = Nil
 		End Sub
 	#tag EndMethod
 
@@ -49,27 +39,9 @@ Implements ErrorHandler
 		End Function
 	#tag EndMethod
 
-	#tag Method, Flags = &h0
-		Function LastError() As Integer
-		  // Part of the libcURL.ErrorHandler interface.
-		  Return mLastError
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h21
-		Private Sub LastError(Assigns NewError As Integer)
-		  // Part of the libcURL.ErrorHandler interface.
-		  mLastError = NewError
-		End Sub
-	#tag EndMethod
-
 
 	#tag Property, Flags = &h1
 		Protected List As Ptr
-	#tag EndProperty
-
-	#tag Property, Flags = &h1
-		Protected mLastError As Integer
 	#tag EndProperty
 
 


### PR DESCRIPTION
The cURLHandle class tracks each call to curl_global_init, and only permits the call if the requested init flags haven't been used yet. It minimizes the number of calls to curl_global_init and ensures that each call is paired with a call to curl_global_cleanup.

cURLItem, cURLMulti, Form, and curl_slist all now subclass cURLHandle. These changes should not affect existing code.