### PR TITLE
Better FormAdd

### DIFF
--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -350,7 +350,7 @@ Implements FormStreamGetter
 		  Dim i As Integer
 		  Do
 		    If i < Index Then
-		      e = e.NextElement()
+		      e = e.NextElement
 		      If e = Nil Then
 		        Dim err As New OutOfBoundsException
 		        err.Message = "The form does not contain an element at that index."

--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -244,9 +244,7 @@ Implements FormStreamGetter
 		        Dim mb As MemoryBlock = FolderItem(v(i)).AbsolutePath + Chr(0) ' make doubleplus sure it's null terminated
 		        m.Append(mb)
 		      Case IsA cURLHandle
-		        Dim mb As New MemoryBlock(4)
-		        mb.Int32Value(0) = cURLHandle(v(i)).Handle
-		        m.Append(mb)
+		        m.Append(Ptr(cURLHandle(v(i)).Handle))
 		      Case IsA MemoryBlock
 		        m.Append(MemoryBlock(v(i)))
 		      Else

--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -83,33 +83,48 @@ Implements FormStreamGetter
 		  e.UploadStream = ValueStream
 		  mStreams.Append(e)
 		  
-		  Dim n As MemoryBlock = Name + Chr(0)
-		  Dim nameopt As Integer = CURLFORM_END
-		  Dim typeopt As Integer = CURLFORM_END
+		  Dim params() As Variant
+		  Dim opts() As Integer
 		  
-		  Dim fn As MemoryBlock = ""
+		  opts.Append(CURLFORM_COPYNAME)
+		  params.Append(Name)
+		  opts.Append(CURLFORM_STREAM)
+		  params.Append(e)
+		  
 		  If Filename.Trim <> "" Then
-		    nameopt = CURLFORM_FILENAME
-		    fn = Filename + Chr(0)
+		    opts.Append(CURLFORM_FILENAME)
+		    params.Append(Filename)
 		  End If
 		  
-		  Dim tn As MemoryBlock = ""
 		  If ContentType.Trim <> "" Then
-		    typeopt = CURLFORM_CONTENTTYPE
-		    tn = ContentType + Chr(0)
+		    opts.Append(CURLFORM_CONTENTTYPE)
+		    params.Append(ContentType)
 		  End If
 		  
-		  Dim headeropt As Integer = CURLFORM_END
 		  If AdditionalHeaders <> Nil Then
-		    headeropt = CURLFORM_CONTENTHEADER
+		    opts.Append(CURLFORM_CONTENTHEADER)
+		    params.Append(AdditionalHeaders)
 		    If mAdditionalHeaders.IndexOf(AdditionalHeaders) = -1 Then mAdditionalHeaders.Append(AdditionalHeaders)
 		  End If
 		  
-		  If ValueSize = 0 Then
-		    Return FormAdd(CURLFORM_COPYNAME, n, CURLFORM_STREAM, Ptr(e.Handle), nameopt, fn, typeopt, tn, headeropt, AdditionalHeaders)
-		  Else
-		    Return FormAdd(CURLFORM_COPYNAME, n, CURLFORM_STREAM, Ptr(e.Handle), CURLFORM_CONTENTSLENGTH, Ptr(ValueSize), nameopt, fn, typeopt, tn, headeropt, AdditionalHeaders)
+		  If ValueSize > 0 Then
+		    opts.Append(CURLFORM_CONTENTSLENGTH)
+		    params.Append(ValueSize)
 		  End If
+		  
+		  
+		  Select Case UBound(opts)
+		  Case 1
+		    Return FormAdd(opts(0), params(0), opts(1), params(1))
+		  Case 2
+		    Return FormAdd(opts(0), params(0), opts(1), params(1), opts(2), params(2))
+		  Case 3
+		    Return FormAdd(opts(0), params(0), opts(1), params(1), opts(2), params(2), opts(3), params(3))
+		  Case 4
+		    Return FormAdd(opts(0), params(0), opts(1), params(1), opts(2), params(2), opts(3), params(3), opts(4), params(4))
+		  Case 5
+		    Return FormAdd(opts(0), params(0), opts(1), params(1), opts(2), params(2), opts(3), params(3), opts(4), params(4), opts(5), params(5))
+		  End Select
 		End Function
 	#tag EndMethod
 

--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -58,7 +58,7 @@ Implements FormStreamGetter
 		  Case ContentType = "" And Filename <> "" ' file part without ContentType
 		    ContentType = MimeType(SpecialFolder.Temporary.Child(Filename))
 		    If ContentType <> "" Then
-		      Return Me.AddElement(Name, Value, Filename, ContentType)
+		      Return Me.AddElement(Name, Value, Filename, ContentType, AdditionalHeaders)
 		    Else
 		      Dim fn As MemoryBlock = Filename + Chr(0)
 		      Return FormAdd(CURLFORM_COPYNAME, n, CURLFORM_BUFFER, fn, CURLFORM_BUFFERLENGTH, Ptr(Value.Size), CURLFORM_BUFFERPTR, Value, headeropt, AdditionalHeaders)

--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -12,7 +12,10 @@ Implements FormStreamGetter
 		  If Value.Exists And Not Value.Directory Then
 		    If ContentType = "" Then ContentType = MimeType(Value)
 		    Dim headeropt As Integer = CURLFORM_END
-		    If AdditionalHeaders <> Nil Then headeropt = CURLFORM_CONTENTHEADER
+		    If AdditionalHeaders <> Nil Then
+		      headeropt = CURLFORM_CONTENTHEADER
+		      If mAdditionalHeaders.IndexOf(AdditionalHeaders) = -1 Then mAdditionalHeaders.Append(AdditionalHeaders)
+		    End If
 		    If ContentType <> "" Then
 		      Return FormAdd(CURLFORM_COPYNAME, Name, CURLFORM_FILE, Value.ShellPath, CURLFORM_FILENAME, Value.Name, CURLFORM_CONTENTTYPE, ContentType, headeropt, AdditionalHeaders)
 		    Else
@@ -38,7 +41,10 @@ Implements FormStreamGetter
 		  If Value Is Nil Then Raise New NilObjectException
 		  If Value.Size < 0 Then Raise New OutOfBoundsException
 		  Dim headeropt As Integer = CURLFORM_END
-		  If AdditionalHeaders <> Nil Then headeropt = CURLFORM_CONTENTHEADER
+		  If AdditionalHeaders <> Nil Then
+		    headeropt = CURLFORM_CONTENTHEADER
+		    If mAdditionalHeaders.IndexOf(AdditionalHeaders) = -1 Then mAdditionalHeaders.Append(AdditionalHeaders)
+		  End If
 		  Dim n As MemoryBlock = Name + Chr(0)
 		  Select Case True
 		  Case ContentType <> "" And Filename <> "" ' file part with ContentType
@@ -94,7 +100,10 @@ Implements FormStreamGetter
 		  End If
 		  
 		  Dim headeropt As Integer = CURLFORM_END
-		  If AdditionalHeaders <> Nil Then headeropt = CURLFORM_CONTENTHEADER
+		  If AdditionalHeaders <> Nil Then
+		    headeropt = CURLFORM_CONTENTHEADER
+		    If mAdditionalHeaders.IndexOf(AdditionalHeaders) = -1 Then mAdditionalHeaders.Append(AdditionalHeaders)
+		  End If
 		  
 		  If ValueSize = 0 Then
 		    Return FormAdd(CURLFORM_COPYNAME, n, CURLFORM_STREAM, Ptr(e.Handle), nameopt, fn, typeopt, tn, headeropt, AdditionalHeaders)
@@ -112,6 +121,7 @@ Implements FormStreamGetter
 		  ' https://github.com/charonn0/RB-libcURL/wiki/libcURL.MultipartForm.AddElement
 		  
 		  If AdditionalHeaders <> Nil Then
+		    If mAdditionalHeaders.IndexOf(AdditionalHeaders) = -1 Then mAdditionalHeaders.Append(AdditionalHeaders)
 		    Return FormAdd(CURLFORM_COPYNAME, Name, CURLFORM_COPYCONTENTS, Value, CURLFORM_CONTENTHEADER, AdditionalHeaders)
 		  Else
 		    Return FormAdd(CURLFORM_COPYNAME, Name, CURLFORM_COPYCONTENTS, Value)
@@ -1934,13 +1944,13 @@ Implements FormStreamGetter
 	#tag EndProperty
 
 	#tag Property, Flags = &h1
+		#tag Note
+			This array merely holds references to any header lists being used, to prevent them from going out of scope too early.
+		#tag EndNote
 		Protected mAdditionalHeaders() As libcURL.ListPtr
 	#tag EndProperty
 
 	#tag Property, Flags = &h1
-		#tag Note
-			This array merely holds references to any header lists being used, to prevent them from going out of scope too early.
-		#tag EndNote
 		Protected mStreams() As libcURL.EasyHandle
 	#tag EndProperty
 

--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -1821,6 +1821,10 @@ Implements FormStreamGetter
 		    Case value IsA Readable ' rtfm about CURLFORM_STREAM before using this
 		      If Not Me.AddElement(item, Readable(value), 0) Then Raise New cURLException(Me)
 		      
+		    Case value IsA MemoryBlock
+		      Dim mb As MemoryBlock = Value
+		      If Not Me.AddElement(item, mb, "") Then Raise New cURLException(Me)
+		      
 		    Else
 		      Raise New UnsupportedFormatException
 		    End Select

--- a/libcURL/MultipartForm.rbbas
+++ b/libcURL/MultipartForm.rbbas
@@ -197,8 +197,8 @@ Implements FormStreamGetter
 		End Sub
 	#tag EndMethod
 
-	#tag Method, Flags = &h1
-		Protected Function FormAdd(Optional AdditionalHeaders As libcURL.ListPtr, Option As Integer, Value As MemoryBlock, Option1 As Integer = CURLFORM_END, Value1 As MemoryBlock = Nil, Option2 As Integer = CURLFORM_END, Value2 As MemoryBlock = Nil, Option3 As Integer = CURLFORM_END, Value3 As MemoryBlock = Nil, Option4 As Integer = CURLFORM_END, Value4 As MemoryBlock = Nil, Option5 As Integer = CURLFORM_END, Value5 As MemoryBlock = Nil) As Boolean
+	#tag Method, Flags = &h0
+		Function FormAdd(Optional AdditionalHeaders As libcURL.ListPtr, Option As Integer, Value As Variant, Option1 As Integer = CURLFORM_END, Value1 As Variant = Nil, Option2 As Integer = CURLFORM_END, Value2 As Variant = Nil, Option3 As Integer = CURLFORM_END, Value3 As Variant = Nil, Option4 As Integer = CURLFORM_END, Value4 As Variant = Nil, Option5 As Integer = CURLFORM_END, Value5 As Variant = Nil, Option6 As Integer = CURLFORM_END, Value6 As Variant = Nil, Option7 As Integer = CURLFORM_END, Value7 As Variant = Nil, Option8 As Integer = CURLFORM_END, Value8 As Variant = Nil, Option9 As Integer = CURLFORM_END, Value9 As Variant = Nil) As Boolean
 		  ' This helper function is a wrapper for the variadic external method curl_formadd. Since external methods
 		  ' can't be variadic, this method simulates it by accepting a finite number of optional arguments.
 		  '
@@ -216,35 +216,43 @@ Implements FormStreamGetter
 		  ' http://curl.haxx.se/libcurl/c/curl_formadd.html
 		  ' https://github.com/charonn0/RB-libcURL/wiki/libcURL.MultipartForm.FormAdd
 		  
-		  If Value <> Nil Then Value = Value + Chr(0)
-		  If Value1 <> Nil Then Value1 = Value1 + Chr(0)
-		  If Value2 <> Nil Then Value2 = Value2 + Chr(0)
-		  If Value3 <> Nil Then Value3 = Value3 + Chr(0)
-		  If Value4 <> Nil Then Value4 = Value4 + Chr(0)
-		  If Value5 <> Nil Then Value5 = Value5 + Chr(0)
+		  Dim v() As Variant = Array(Value, Value1, Value2, Value3, Value4, Value5, Value6, Value7, Value8, Value9)
+		  Dim m() As MemoryBlock
+		  Dim o() As Integer = Array(Option, Option1, Option2, Option3, Option4, Option5, Option6, Option7, Option8, Option9)
+		  For i As Integer = 0 To UBound(v)
+		    Select Case VarType(v(i))
+		    Case Variant.TypeNil
+		      m.Append(New MemoryBlock(0))
+		      
+		    Case Variant.TypePtr, Variant.TypeInteger
+		      m.Append(v(i).PtrValue)
+		      
+		    Case Variant.TypeObject
+		      Select Case v(i)
+		      Case IsA FolderItem
+		        Dim mb As MemoryBlock = FolderItem(v(i)).AbsolutePath + Chr(0) ' make doubleplus sure it's null terminated
+		        m.Append(mb)
+		      Case IsA cURLHandle
+		        Dim mb As New MemoryBlock(4)
+		        mb.Int32Value(0) = cURLHandle(v(i)).Handle
+		        m.Append(mb)
+		      End Select
+		      
+		    Case Variant.TypeString
+		      Dim mb As MemoryBlock = v(i).StringValue + Chr(0) ' make doubleplus sure it's null terminated
+		      m.Append(mb)
+		      
+		    End Select
+		  Next
 		  
-		  
-		  Select Case True
-		  Case Option1 = CURLFORM_END
-		    Return FormAddPtr(AdditionalHeaders, Option, Value)
-		  Case Option2 = CURLFORM_END
-		    Return FormAddPtr(AdditionalHeaders, Option, Value, Option1, Value1)
-		  Case Option3 = CURLFORM_END
-		    Return FormAddPtr(AdditionalHeaders, Option, Value, Option1, Value1, Option2, Value2)
-		  Case Option4 = CURLFORM_END
-		    Return FormAddPtr(AdditionalHeaders, Option, Value, Option1, Value1, Option2, Value2, Option3, Value3)
-		  Case Option5 = CURLFORM_END
-		    Return FormAddPtr(AdditionalHeaders, Option, Value, Option1, Value1, Option2, Value2, Option3, Value3, Option4, Value4)
-		  Else
-		    Return FormAddPtr(AdditionalHeaders, Option, Value, Option1, Value1, Option2, Value2, Option3, Value3, Option4, Value4, Option5, Value5)
-		  End Select
+		  Return FormAddPtr(AdditionalHeaders, o(0), m(0), o(1), m(1), o(2), m(2), o(3), m(3), o(4), m(4), o(5), m(5), o(6), m(6), o(7), m(7), o(8), m(8), o(9), m(9))
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function FormAddPtr(AdditionalHeaders As libcURL.ListPtr, Option As Integer, Value As Ptr, Option1 As Integer = CURLFORM_END, Value1 As Ptr = Nil, Option2 As Integer = CURLFORM_END, Value2 As Ptr = Nil, Option3 As Integer = CURLFORM_END, Value3 As Ptr = Nil, Option4 As Integer = CURLFORM_END, Value4 As Ptr = Nil, Option5 As Integer = CURLFORM_END, Value5 As Ptr = Nil) As Boolean
-		  Dim option6 As Integer = CURLFORM_END
-		  Dim value6 As Ptr
+		Protected Function FormAddPtr(AdditionalHeaders As libcURL.ListPtr, Option As Integer, Value As Ptr, Option1 As Integer = CURLFORM_END, Value1 As Ptr = Nil, Option2 As Integer = CURLFORM_END, Value2 As Ptr = Nil, Option3 As Integer = CURLFORM_END, Value3 As Ptr = Nil, Option4 As Integer = CURLFORM_END, Value4 As Ptr = Nil, Option5 As Integer = CURLFORM_END, Value5 As Ptr = Nil, Option6 As Integer = CURLFORM_END, Value6 As Ptr = Nil, Option7 As Integer = CURLFORM_END, Value7 As Ptr = Nil, Option8 As Integer = CURLFORM_END, Value8 As Ptr = Nil, Option9 As Integer = CURLFORM_END, Value9 As Ptr = Nil) As Boolean
+		  Dim option10 As Integer = CURLFORM_END
+		  Dim value10 As Ptr
 		  
 		  If AdditionalHeaders <> Nil Then
 		    Select Case True
@@ -263,18 +271,34 @@ Implements FormStreamGetter
 		    Case Option5 = CURLFORM_END
 		      Option5 = CURLFORM_CONTENTHEADER
 		      Value5 = Ptr(AdditionalHeaders.Handle)
-		    Else
+		    Case Option6 = CURLFORM_END
 		      Option6 = CURLFORM_CONTENTHEADER
 		      Value6 = Ptr(AdditionalHeaders.Handle)
+		    Case Option7 = CURLFORM_END
+		      Option7 = CURLFORM_CONTENTHEADER
+		      Value7 = Ptr(AdditionalHeaders.Handle)
+		    Case Option8 = CURLFORM_END
+		      Option8 = CURLFORM_CONTENTHEADER
+		      Value8 = Ptr(AdditionalHeaders.Handle)
+		    Case Option9 = CURLFORM_END
+		      Option9 = CURLFORM_CONTENTHEADER
+		      Value9 = Ptr(AdditionalHeaders.Handle)
+		    Case Option10 = CURLFORM_END
+		      Option10 = CURLFORM_CONTENTHEADER
+		      Value10 = Ptr(AdditionalHeaders.Handle)
+		    Else
+		      Option10 = CURLFORM_CONTENTHEADER
+		      Value10 = Ptr(AdditionalHeaders.Handle)
 		    End Select
 		    
 		    mLastError = curl_formadd(mHandle, LastItem, Option, Value, Option1, Value1, _
-		    Option2, Value2, Option3, Value3, Option4, Value4, Option5, Value5, Option6, Value6, CURLFORM_END)
+		    Option2, Value2, Option3, Value3, Option4, Value4, Option5, Value5, Option6, Value6, Option7, Value7, Option8, Value8, Option9, Value9, Option10, Value10, CURLFORM_END)
 		    If mLastError <> 0 Then mAdditionalHeaders.Append(AdditionalHeaders)
 		    
 		  Else
 		    mLastError = curl_formadd(mHandle, LastItem, Option, Value, Option1, Value1, _
-		    Option2, Value2, Option3, Value3, Option4, Value4, Option5, Value5, CURLFORM_END, Nil, CURLFORM_END)
+		    Option2, Value2, Option3, Value3, Option4, Value4, Option5, Value5, Option6, Value6, Option7, Value7, Option8, Value8, Option9, Value9, Option10, Nil, CURLFORM_END)
+		    
 		  End If
 		  Return mLastError = 0
 		End Function
@@ -1946,46 +1970,46 @@ Implements FormStreamGetter
 	#tag EndProperty
 
 
-	#tag Constant, Name = CURLFORM_BUFFER, Type = Double, Dynamic = False, Default = \"11", Scope = Protected
+	#tag Constant, Name = CURLFORM_BUFFER, Type = Double, Dynamic = False, Default = \"11", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_BUFFERLENGTH, Type = Double, Dynamic = False, Default = \"13", Scope = Protected
+	#tag Constant, Name = CURLFORM_BUFFERLENGTH, Type = Double, Dynamic = False, Default = \"13", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_BUFFERPTR, Type = Double, Dynamic = False, Default = \"12", Scope = Protected
+	#tag Constant, Name = CURLFORM_BUFFERPTR, Type = Double, Dynamic = False, Default = \"12", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_CONTENTHEADER, Type = Double, Dynamic = False, Default = \"15", Scope = Protected
+	#tag Constant, Name = CURLFORM_CONTENTHEADER, Type = Double, Dynamic = False, Default = \"15", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_CONTENTLEN, Type = Double, Dynamic = False, Default = \"20", Scope = Protected
+	#tag Constant, Name = CURLFORM_CONTENTLEN, Type = Double, Dynamic = False, Default = \"20", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_CONTENTSLENGTH, Type = Double, Dynamic = False, Default = \"6", Scope = Protected
+	#tag Constant, Name = CURLFORM_CONTENTSLENGTH, Type = Double, Dynamic = False, Default = \"6", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_CONTENTTYPE, Type = Double, Dynamic = False, Default = \"14", Scope = Protected
+	#tag Constant, Name = CURLFORM_CONTENTTYPE, Type = Double, Dynamic = False, Default = \"14", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_COPYCONTENTS, Type = Double, Dynamic = False, Default = \"4", Scope = Protected
+	#tag Constant, Name = CURLFORM_COPYCONTENTS, Type = Double, Dynamic = False, Default = \"4", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_COPYNAME, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
+	#tag Constant, Name = CURLFORM_COPYNAME, Type = Double, Dynamic = False, Default = \"1", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_END, Type = Double, Dynamic = False, Default = \"17", Scope = Protected
+	#tag Constant, Name = CURLFORM_END, Type = Double, Dynamic = False, Default = \"17", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_FILE, Type = Double, Dynamic = False, Default = \"10", Scope = Protected
+	#tag Constant, Name = CURLFORM_FILE, Type = Double, Dynamic = False, Default = \"10", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_FILECONTENT, Type = Double, Dynamic = False, Default = \"7", Scope = Protected
+	#tag Constant, Name = CURLFORM_FILECONTENT, Type = Double, Dynamic = False, Default = \"7", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_FILENAME, Type = Double, Dynamic = False, Default = \"16", Scope = Protected
+	#tag Constant, Name = CURLFORM_FILENAME, Type = Double, Dynamic = False, Default = \"16", Scope = Public
 	#tag EndConstant
 
-	#tag Constant, Name = CURLFORM_STREAM, Type = Double, Dynamic = False, Default = \"19", Scope = Protected
+	#tag Constant, Name = CURLFORM_STREAM, Type = Double, Dynamic = False, Default = \"19", Scope = Public
 	#tag EndConstant
 
 

--- a/libcURL/libcURL.rbbas
+++ b/libcURL/libcURL.rbbas
@@ -87,7 +87,7 @@ Protected Module libcURL
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function curl_formadd Lib "libcurl" (ByRef FirstItem As Integer, ByRef LastItem As Ptr, Option As Integer, Value As Ptr, Option1 As Integer, Value1 As Ptr, Option2 As Integer, Value2 As Ptr, Option3 As Integer, Value3 As Ptr, Option4 As Integer, Value4 As Ptr, Option5 As Integer, Value5 As Ptr, Option6 As Integer, Value6 As Ptr, FinalOption As Integer) As Integer
+		Private Soft Declare Function curl_formadd Lib "libcurl" (ByRef FirstItem As Integer, ByRef LastItem As Ptr, Option As Integer, Value As Ptr, Option1 As Integer, Value1 As Ptr, Option2 As Integer, Value2 As Ptr, Option3 As Integer, Value3 As Ptr, Option4 As Integer, Value4 As Ptr, Option5 As Integer, Value5 As Ptr, Option6 As Integer, Value6 As Ptr, Option7 As Integer, Value7 As Ptr, Option8 As Integer, Value8 As Ptr, Option9 As Integer, Value9 As Ptr, Option10 As Integer, Value10 As Ptr, FinalOption As Integer) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21


### PR DESCRIPTION
This PR Adds a public version of the FormAdd method, which accepts Variants instead of only strings.  Also, the maximum number of argument pairs to FormAdd has been increased from 6 to 10. This allows users to use features of libcurl which are too complex for the AddElement methods, such as nested forms. 

For example, this would create a form with 2 string elements and a nested form containing 3 file elements:

```vbnet
  Dim m As New libcURL.MultipartForm
  Call m.AddElement("Username", "Bob")
  Call m.AddElement("Password", "seekrit")
  Dim files() As FolderItem = Array(GetOpenFolderItem(""), GetOpenFolderItem(""), GetOpenFolderItem(""))
  Call m.FormAdd(m.CURLFORM_COPYNAME, "MyNestedForm", m.CURLFORM_FILE, files(0), m.CURLFORM_FILE, files(1), m.CURLFORM_FILE, files(2))
  
  Dim c As New cURLClient
  If Not c.Post("http://www.example.com/submit.php", m) Then MsgBox("Error")
  ```

This PR also includes significant refactoring of the AddElement and FormAdd methods, but there are no public breaking changes.